### PR TITLE
Update Makefile to C11 with POSIX feature macros

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,30 @@
 CC = gcc
-CFLAGS = -Wall -Wextra -std=c99 -g -Iinclude
+CFLAGS = -Wall -Wextra -Werror -std=c11 -g -Iinclude -D_POSIX_C_SOURCE=200809L -D_GNU_SOURCE
+LDFLAGS = -lpthread
+
 SRC_DIR = src
 BUILD_DIR = build
+
 SRCS = $(wildcard $(SRC_DIR)/*.c)
 OBJS = $(patsubst $(SRC_DIR)/%.c, $(BUILD_DIR)/%.o, $(SRCS))
 TARGET = $(BUILD_DIR)/cougfs
 
 all: $(TARGET)
+
 $(TARGET): $(OBJS)
 	@mkdir -p $(BUILD_DIR)
-	$(CC) $(CFLAGS) -o $@ $^
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 	@echo "✓ Built: $@"
+
 $(BUILD_DIR)/%.o: $(SRC_DIR)/%.c
 	@mkdir -p $(BUILD_DIR)
 	$(CC) $(CFLAGS) -c $< -o $@
+
 test: all
 	@echo "✓ Ready for testing"
+
 clean:
 	rm -rf $(BUILD_DIR) *.o disk.img
 	@echo "✓ Clean complete"
+
 .PHONY: all test clean


### PR DESCRIPTION
Fixes CI warning for implicit declaration of ftruncate.

- -std=c99 → -std=c11
- Added -D_POSIX_C_SOURCE=200809L
- Added -Werror
- Added -D_GNU_SOURCE