### PR TITLE
Implement write-ahead journaling for crash recovery

### DIFF
--- a/include/file.h
+++ b/include/file.h
@@ -1,0 +1,59 @@
+/*
+ * CougFS: File Operations
+ *
+ * Create, read, write, delete, and truncate files.
+ */
+
+#ifndef FILE_H
+#define FILE_H
+
+#include "cougfs.h"
+
+/* File descriptor table entry */
+typedef struct {
+    int      in_use;         /* 1 if this fd is open */
+    uint32_t inode;          /* inode number */
+    uint32_t offset;         /* current read/write offset */
+    int      flags;          /* open flags */
+} cougfs_fd_t;
+
+#define MAX_OPEN_FILES 64
+
+/* Open flags */
+#define COUGFS_O_RDONLY  0x01
+#define COUGFS_O_WRONLY  0x02
+#define COUGFS_O_RDWR    0x03
+#define COUGFS_O_CREAT   0x10
+#define COUGFS_O_TRUNC   0x20
+
+/* Initialize the file descriptor table. */
+void file_init(void);
+
+/* Create a new file in a directory. Returns the file's inode or -1. */
+int file_create(uint32_t dir_ino, const char *name, uint16_t mode);
+
+/* Open a file. Returns file descriptor index or -1. */
+int file_open(uint32_t ino, int flags);
+
+/* Read up to count bytes from fd into buf. Returns bytes read or -1. */
+int file_read(int fd, void *buf, uint32_t count);
+
+/* Write count bytes from buf to fd. Returns bytes written or -1. */
+int file_write(int fd, const void *buf, uint32_t count);
+
+/* Seek to offset in fd. whence: 0=SET, 1=CUR, 2=END. Returns new offset or -1. */
+int file_seek(int fd, int32_t offset, int whence);
+
+/* Close a file descriptor. Returns 0 on success. */
+int file_close(int fd);
+
+/* Delete (unlink) a file from a directory. Returns 0 on success. */
+int file_delete(uint32_t dir_ino, const char *name);
+
+/* Truncate a file to the given size. Returns 0 on success. */
+int file_truncate(uint32_t ino, uint32_t new_size);
+
+/* Get the stat info for a file. Returns 0 on success. */
+int file_stat(uint32_t ino, cougfs_inode_t *out);
+
+#endif /* FILE_H */

--- a/include/journal.h
+++ b/include/journal.h
@@ -1,0 +1,57 @@
+/*
+ * CougFS: Journaling / Crash Recovery
+ *
+ * Write-ahead log for metadata operations. Each transaction records
+ * block-level changes before they are committed to the main filesystem.
+ */
+
+#ifndef JOURNAL_H
+#define JOURNAL_H
+
+#include "cougfs.h"
+
+/* Journal entry types */
+#define JOURNAL_OP_NONE       0
+#define JOURNAL_OP_WRITE      1   /* a block write */
+#define JOURNAL_OP_COMMIT     2   /* transaction commit marker */
+
+/* Journal header: stored at the start of the journal area */
+typedef struct {
+    uint32_t magic;               /* COUGFS_MAGIC */
+    uint32_t head;                /* next write position (byte offset in journal) */
+    uint32_t tail;                /* oldest uncommitted entry */
+    uint32_t seq;                 /* sequence number */
+    uint8_t  padding[BLOCK_SIZE - 16];
+} journal_header_t;
+
+/* Journal entry: describes one logged block write */
+typedef struct {
+    uint32_t seq;                 /* transaction sequence number */
+    uint32_t op;                  /* operation type */
+    uint32_t block_num;           /* target block on disk */
+    uint32_t data_len;            /* bytes of data (up to BLOCK_SIZE) */
+    /* Followed by data_len bytes of block data in the journal */
+} journal_entry_t;
+
+/* Initialize the journal. Returns 0 on success. */
+int journal_init(void);
+
+/* Begin a new transaction. Returns transaction ID. */
+uint32_t journal_begin(void);
+
+/* Log a block write within a transaction. Returns 0 on success. */
+int journal_log_write(uint32_t txn_id, uint32_t block_num, const void *data);
+
+/* Commit a transaction. Returns 0 on success. */
+int journal_commit(uint32_t txn_id);
+
+/* Abort a transaction (discard logged entries). */
+void journal_abort(uint32_t txn_id);
+
+/* Replay the journal to recover from a crash. Returns 0 on success. */
+int journal_recover(void);
+
+/* Sync journal to disk. */
+void journal_sync(void);
+
+#endif /* JOURNAL_H */

--- a/src/journal.c
+++ b/src/journal.c
@@ -57,9 +57,56 @@ int journal_log_write(uint32_t txn_id, uint32_t block_num, const void *data)
 
 int journal_commit(uint32_t txn_id)
 {
-    /* TODO: implement */
-    (void)txn_id;
-    return -1;
+    if (!active_txn.active || active_txn.seq != txn_id)
+        return -1;
+    uint32_t journal_block = JOURNAL_START + 1;
+    for (int i = 0; i < active_txn.count; i++) {
+        if (journal_block >= JOURNAL_START + JOURNAL_BLOCKS) {
+            fprintf(stderr, "journal_commit: journal full\n");
+            journal_abort(txn_id);
+            return -1;
+        }
+        uint8_t entry_block[BLOCK_SIZE];
+        memset(entry_block, 0, BLOCK_SIZE);
+        journal_entry_t *entry = (journal_entry_t *)entry_block;
+        entry->seq = txn_id;
+        entry->op = JOURNAL_OP_WRITE;
+        entry->block_num = active_txn.block_nums[i];
+        entry->data_len = BLOCK_SIZE - sizeof(journal_entry_t);
+        memcpy(entry_block + sizeof(journal_entry_t),
+               active_txn.data[i],
+               BLOCK_SIZE - sizeof(journal_entry_t));
+        if (disk_write_block(journal_block, entry_block) < 0)
+            return -1;
+        journal_block++;
+    }
+    if (journal_block < JOURNAL_START + JOURNAL_BLOCKS) {
+        uint8_t commit_block[BLOCK_SIZE];
+        memset(commit_block, 0, BLOCK_SIZE);
+        journal_entry_t *commit = (journal_entry_t *)commit_block;
+        commit->seq = txn_id;
+        commit->op = JOURNAL_OP_COMMIT;
+        commit->block_num = 0;
+        commit->data_len = 0;
+        disk_write_block(journal_block, commit_block);
+    }
+    disk_sync();
+    for (int i = 0; i < active_txn.count; i++) {
+        disk_write_block(active_txn.block_nums[i], active_txn.data[i]);
+    }
+    disk_sync();
+    jheader.seq = current_seq;
+    jheader.head = 0;
+    jheader.tail = 0;
+    disk_write_block(JOURNAL_START, &jheader);
+    uint8_t zeros[BLOCK_SIZE];
+    memset(zeros, 0, BLOCK_SIZE);
+    for (uint32_t b = JOURNAL_START + 1; b < JOURNAL_START + JOURNAL_BLOCKS; b++) {
+        disk_write_block(b, zeros);
+    }
+    disk_sync();
+    active_txn.active = 0;
+    return 0;
 }
 
 void journal_abort(uint32_t txn_id)
@@ -72,8 +119,63 @@ void journal_abort(uint32_t txn_id)
 
 int journal_recover(void)
 {
-    /* TODO: implement */
-    return -1;
+    printf("CougFS journal: scanning for uncommitted transactions...\n");
+    int found_commit = 0;
+    int entry_count = 0;
+    uint32_t committed_seq = 0;
+    for (uint32_t b = JOURNAL_START + 1; b < JOURNAL_START + JOURNAL_BLOCKS; b++) {
+        uint8_t block[BLOCK_SIZE];
+        if (disk_read_block(b, block) < 0)
+            continue;
+        journal_entry_t *entry = (journal_entry_t *)block;
+        if (entry->op == JOURNAL_OP_COMMIT && entry->seq > 0) {
+            found_commit = 1;
+            committed_seq = entry->seq;
+            break;
+        }
+        if (entry->op == JOURNAL_OP_WRITE && entry->seq > 0) {
+            entry_count++;
+        }
+    }
+    if (!found_commit) {
+        printf("CougFS journal: no committed transactions to replay\n");
+        uint8_t zeros[BLOCK_SIZE];
+        memset(zeros, 0, BLOCK_SIZE);
+        for (uint32_t b = JOURNAL_START + 1; b < JOURNAL_START + JOURNAL_BLOCKS; b++) {
+            disk_write_block(b, zeros);
+        }
+        return 0;
+    }
+    printf("CougFS journal: replaying transaction %u (%d entries)\n",
+           committed_seq, entry_count);
+    for (uint32_t b = JOURNAL_START + 1; b < JOURNAL_START + JOURNAL_BLOCKS; b++) {
+        uint8_t block[BLOCK_SIZE];
+        if (disk_read_block(b, block) < 0)
+            continue;
+        journal_entry_t *entry = (journal_entry_t *)block;
+        if (entry->op == JOURNAL_OP_WRITE && entry->seq == committed_seq) {
+            uint8_t restored[BLOCK_SIZE];
+            memset(restored, 0, BLOCK_SIZE);
+            memcpy(restored, block + sizeof(journal_entry_t),
+                   BLOCK_SIZE - sizeof(journal_entry_t));
+            printf("  replaying block %u\n", entry->block_num);
+            disk_write_block(entry->block_num, restored);
+        }
+        if (entry->op == JOURNAL_OP_COMMIT)
+            break;
+    }
+    uint8_t zeros[BLOCK_SIZE];
+    memset(zeros, 0, BLOCK_SIZE);
+    for (uint32_t b = JOURNAL_START + 1; b < JOURNAL_START + JOURNAL_BLOCKS; b++) {
+        disk_write_block(b, zeros);
+    }
+    jheader.seq = committed_seq + 1;
+    jheader.head = 0;
+    jheader.tail = 0;
+    disk_write_block(JOURNAL_START, &jheader);
+    disk_sync();
+    printf("CougFS journal: recovery complete\n");
+    return 0;
 }
 
 void journal_sync(void)

--- a/src/journal.c
+++ b/src/journal.c
@@ -1,0 +1,83 @@
+#include <stdio.h>
+#include <string.h>
+#include "journal.h"
+#include "disk.h"
+
+static journal_header_t jheader;
+static uint32_t current_seq;
+
+#define MAX_TXN_ENTRIES 16
+
+typedef struct {
+    int      active;
+    uint32_t seq;
+    int      count;
+    uint32_t block_nums[MAX_TXN_ENTRIES];
+    uint8_t  data[MAX_TXN_ENTRIES][BLOCK_SIZE];
+} txn_buffer_t;
+
+static txn_buffer_t active_txn;
+
+int journal_init(void)
+{
+    if (disk_read_block(JOURNAL_START, &jheader) < 0)
+        return -1;
+    if (jheader.magic != COUGFS_MAGIC) {
+        memset(&jheader, 0, sizeof(jheader));
+        jheader.magic = COUGFS_MAGIC;
+        jheader.head = 0;
+        jheader.tail = 0;
+        jheader.seq = 1;
+        disk_write_block(JOURNAL_START, &jheader);
+    }
+    current_seq = jheader.seq;
+    memset(&active_txn, 0, sizeof(active_txn));
+    return 0;
+}
+
+uint32_t journal_begin(void)
+{
+    active_txn.active = 1;
+    active_txn.seq = current_seq++;
+    active_txn.count = 0;
+    return active_txn.seq;
+}
+
+int journal_log_write(uint32_t txn_id, uint32_t block_num, const void *data)
+{
+    if (!active_txn.active || active_txn.seq != txn_id)
+        return -1;
+    if (active_txn.count >= MAX_TXN_ENTRIES)
+        return -1;
+    int idx = active_txn.count++;
+    active_txn.block_nums[idx] = block_num;
+    memcpy(active_txn.data[idx], data, BLOCK_SIZE);
+    return 0;
+}
+
+int journal_commit(uint32_t txn_id)
+{
+    /* TODO: implement */
+    (void)txn_id;
+    return -1;
+}
+
+void journal_abort(uint32_t txn_id)
+{
+    if (active_txn.active && active_txn.seq == txn_id) {
+        active_txn.active = 0;
+        active_txn.count = 0;
+    }
+}
+
+int journal_recover(void)
+{
+    /* TODO: implement */
+    return -1;
+}
+
+void journal_sync(void)
+{
+    disk_write_block(JOURNAL_START, &jheader);
+    disk_sync();
+}


### PR DESCRIPTION
Closes #<JOURNAL_ISSUE_NUMBER>

Implements transaction-based write-ahead journal for crash recovery.

### Changes
- Added journal.h with entry types and transaction structures
- Implemented journal_init, journal_begin, journal_log_write
- Implemented journal_commit with write-ahead protocol
- Implemented journal_abort to discard transactions
- Implemented journal_recover to replay committed transactions on dirty mount