### PR TITLE
Add Valgrind memory check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: sudo apt-get update && sudo apt-get install -y build-essential
+      - run: sudo apt-get update && sudo apt-get install -y build-essential valgrind
       - run: make clean && make
       - run: make test
+      - run: make valgrind


### PR DESCRIPTION
Closes #<CI_ISSUE_NUMBER>

Adds memory leak detection to CI pipeline.