### PR TITLE
fix: enforce MAX_FILE_BLOCKS limit in inode_truncate

### DIFF
--- a/include/cougfs.h
+++ b/include/cougfs.h
@@ -61,6 +61,7 @@
 
 /* Maximum file size: 12 direct + 1024 indirect = 1036 blocks */
 #define MAX_FILE_BLOCKS    (DIRECT_BLOCKS + (BLOCK_SIZE / sizeof(uint32_t)))
+#define MAX_FILE_SIZE      (MAX_FILE_BLOCKS * BLOCK_SIZE)
 
 /*
  * Superblock: stored in block 0.

--- a/src/file.c
+++ b/src/file.c
@@ -117,6 +117,10 @@ int file_write(int fd, const void *buf, uint32_t count)
     if (inode_read(fd_table[fd].inode, &inode) < 0)
         return -1;
     uint32_t offset = fd_table[fd].offset;
+    if (offset >= MAX_FILE_SIZE)
+        return count == 0 ? 0 : -1;
+    if (count > MAX_FILE_SIZE - offset)
+        count = MAX_FILE_SIZE - offset;
     uint32_t bytes_written = 0;
     uint8_t block_buf[BLOCK_SIZE];
     while (bytes_written < count) {
@@ -162,6 +166,8 @@ int file_seek(int fd, int32_t offset, int whence)
     default: return -1;
     }
     if (new_offset < 0)
+        return -1;
+    if ((uint32_t)new_offset > MAX_FILE_SIZE)
         return -1;
     fd_table[fd].offset = (uint32_t)new_offset;
     return (int)fd_table[fd].offset;

--- a/src/inode.c
+++ b/src/inode.c
@@ -142,6 +142,9 @@ uint32_t inode_get_block(cougfs_inode_t *inode, uint32_t logical_block, int allo
 
 int inode_truncate(uint32_t ino, cougfs_inode_t *inode, uint32_t new_size)
 {
+    if (new_size > MAX_FILE_SIZE)
+        return -1;
+
     uint32_t old_blocks = (inode->size + BLOCK_SIZE - 1) / BLOCK_SIZE;
     uint32_t new_blocks = (new_size + BLOCK_SIZE - 1) / BLOCK_SIZE;
     if (new_size == 0)

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -265,6 +265,11 @@ static void test_file(void)
     ASSERT(file_stat(ino, &stat_inode) == 0, "stat after truncate");
     ASSERT(stat_inode.size == 5, "truncated size is correct");
 
+    ASSERT(file_truncate(ino, MAX_FILE_SIZE + 1) < 0,
+           "truncate past max file size fails");
+    ASSERT(file_stat(ino, &stat_inode) == 0, "stat after failed truncate");
+    ASSERT(stat_inode.size == 5, "failed truncate preserves size");
+
     /* Delete */
     ASSERT(file_delete(ROOT_INODE, "hello.txt") == 0, "file_delete succeeds");
     ASSERT(dir_lookup(ROOT_INODE, "hello.txt") < 0, "deleted file not found");
@@ -281,6 +286,14 @@ static void test_file(void)
     memset(big_data, 'X', sizeof(big_data));
     written = file_write(fd, big_data, sizeof(big_data));
     ASSERT(written == (int)sizeof(big_data), "write 8KB succeeds");
+
+    ASSERT(file_seek(fd, MAX_FILE_SIZE + 1, 0) < 0,
+           "seek past max file size fails");
+    ASSERT(file_seek(fd, MAX_FILE_SIZE - 1, 0) == MAX_FILE_SIZE - 1,
+           "seek to last valid byte succeeds");
+    ASSERT(file_write(fd, "YZ", 2) == 1, "write is capped at max file size");
+    ASSERT(file_stat(ino, &stat_inode) == 0, "stat after capped write");
+    ASSERT(stat_inode.size == MAX_FILE_SIZE, "capped write grows to max size");
 
     /* Read it back */
     file_seek(fd, 0, 0);


### PR DESCRIPTION
fix: enforce MAX_FILE_BLOCKS limit in inode_truncate