### PR TITLE
Fix CougFS reliability and safety bugs

### DIFF
--- a/src/fuse_ops.c
+++ b/src/fuse_ops.c
@@ -22,30 +22,50 @@
 /* Helper: split path into parent path and filename */
 static int split_path(const char *path, char *parent, char *name)
 {
+    if (path == NULL || parent == NULL || name == NULL)
+        return -1;
+
+    if (strlen(path) >= 1024)
+        return -1;
+
     char tmp[1024];
+
     strncpy(tmp, path, sizeof(tmp) - 1);
     tmp[sizeof(tmp) - 1] = '\0';
 
     char *last_slash = strrchr(tmp, '/');
+
     if (!last_slash)
+        return -1;
+
+    if (*(last_slash + 1) == '\0')
+        return -1;
+
+    if (strlen(last_slash + 1) > MAX_NAME_LEN)
         return -1;
 
     strncpy(name, last_slash + 1, MAX_NAME_LEN);
     name[MAX_NAME_LEN] = '\0';
 
-    if (last_slash == tmp)
+    if (last_slash == tmp) {
         strcpy(parent, "/");
-    else {
+    } else {
         *last_slash = '\0';
+
+        if (strlen(tmp) >= 1024)
+            return -1;
+
         strncpy(parent, tmp, 1023);
         parent[1023] = '\0';
     }
+
     return 0;
 }
 
 static void inode_to_stat(const cougfs_inode_t *inode, struct stat *st)
 {
     memset(st, 0, sizeof(*st));
+
     st->st_mode = inode->mode;
     st->st_nlink = inode->link_count;
     st->st_uid = inode->uid;
@@ -61,17 +81,23 @@ static void inode_to_stat(const cougfs_inode_t *inode, struct stat *st)
 static int cougfs_getattr(const char *path, struct stat *st)
 {
     fs_read_lock();
+
     int ino = dir_resolve_path(path);
+
     if (ino < 0) {
         fs_read_unlock();
         return -ENOENT;
     }
+
     cougfs_inode_t inode;
-    if (inode_read(ino, &inode) < 0) {
+
+    if (inode_read((uint32_t)ino, &inode) < 0) {
         fs_read_unlock();
         return -EIO;
     }
+
     inode_to_stat(&inode, st);
+
     fs_read_unlock();
     return 0;
 }
@@ -82,25 +108,40 @@ static int cougfs_readdir(const char *path, void *buf,
 {
     (void)offset;
     (void)fi;
+
     fs_read_lock();
+
     int dir_ino = dir_resolve_path(path);
+
     if (dir_ino < 0) {
         fs_read_unlock();
         return -ENOENT;
     }
+
     cougfs_inode_t dir_inode;
-    if (inode_read(dir_ino, &dir_inode) < 0) {
+
+    if (inode_read((uint32_t)dir_ino, &dir_inode) < 0) {
         fs_read_unlock();
         return -EIO;
     }
+
+    if ((dir_inode.mode & COUGFS_S_IFMT) != COUGFS_S_IFDIR) {
+        fs_read_unlock();
+        return -ENOTDIR;
+    }
+
     uint32_t num_blocks = (dir_inode.size + BLOCK_SIZE - 1) / BLOCK_SIZE;
     cougfs_dir_entry_t entries[DIR_ENTRIES_PER_BLOCK];
+
     for (uint32_t b = 0; b < num_blocks; b++) {
         uint32_t blk = inode_get_block(&dir_inode, b, 0);
+
         if (blk == INVALID_BLOCK)
             continue;
+
         if (disk_read_block(blk, entries) < 0)
             continue;
+
         for (int i = 0; i < DIR_ENTRIES_PER_BLOCK; i++) {
             if (entries[i].inode != INVALID_INODE) {
                 if (filler(buf, entries[i].name, NULL, 0) != 0) {
@@ -110,30 +151,38 @@ static int cougfs_readdir(const char *path, void *buf,
             }
         }
     }
+
     fs_read_unlock();
     return 0;
 }
 
 static int cougfs_open(const char *path, struct fuse_file_info *fi)
 {
-    /* file_open updates atime, so we need a write lock */
     fs_write_lock();
+
     int ino = dir_resolve_path(path);
+
     if (ino < 0) {
         fs_write_unlock();
         return -ENOENT;
     }
+
     int flags = COUGFS_O_RDWR;
+
     if ((fi->flags & O_ACCMODE) == O_RDONLY)
         flags = COUGFS_O_RDONLY;
     else if ((fi->flags & O_ACCMODE) == O_WRONLY)
         flags = COUGFS_O_WRONLY;
-    int fd = file_open(ino, flags);
+
+    int fd = file_open((uint32_t)ino, flags);
+
     if (fd < 0) {
         fs_write_unlock();
-        return -EISDIR; /* most likely a directory */
+        return -EISDIR;
     }
+
     fi->fh = fd;
+
     fs_write_unlock();
     return 0;
 }
@@ -142,14 +191,26 @@ static int cougfs_read(const char *path, char *buf, size_t size,
                        off_t offset, struct fuse_file_info *fi)
 {
     (void)path;
+
+    if (offset < 0 || offset > INT32_MAX)
+        return -EINVAL;
+
     if (size > UINT32_MAX)
         return -EINVAL;
-    /* file_read modifies fd offset and atime, needs write lock */
+
     fs_write_lock();
+
     int fd = (int)fi->fh;
-    file_seek(fd, (int32_t)offset, 0);
+
+    if (file_seek(fd, (int32_t)offset, 0) < 0) {
+        fs_write_unlock();
+        return -EINVAL;
+    }
+
     int ret = file_read(fd, buf, (uint32_t)size);
+
     fs_write_unlock();
+
     return ret < 0 ? -EIO : ret;
 }
 
@@ -157,20 +218,37 @@ static int cougfs_write(const char *path, const char *buf, size_t size,
                         off_t offset, struct fuse_file_info *fi)
 {
     (void)path;
+
+    if (offset < 0 || offset > INT32_MAX)
+        return -EINVAL;
+
     if (size > UINT32_MAX)
         return -EINVAL;
+
     fs_write_lock();
+
     int fd = (int)fi->fh;
-    file_seek(fd, (int32_t)offset, 0);
+
+    if (file_seek(fd, (int32_t)offset, 0) < 0) {
+        fs_write_unlock();
+        return -EINVAL;
+    }
+
     int ret = file_write(fd, buf, (uint32_t)size);
+
     fs_write_unlock();
+
     return ret < 0 ? -EIO : ret;
 }
 
 static int cougfs_release(const char *path, struct fuse_file_info *fi)
 {
     (void)path;
+
+    fs_write_lock();
     file_close((int)fi->fh);
+    fs_write_unlock();
+
     return 0;
 }
 
@@ -178,35 +256,44 @@ static int cougfs_create(const char *path, mode_t mode,
                          struct fuse_file_info *fi)
 {
     fs_write_lock();
+
     char parent_path[1024];
     char filename[MAX_NAME_LEN + 1];
+
     if (split_path(path, parent_path, filename) < 0) {
         fs_write_unlock();
         return -EINVAL;
     }
+
     int parent_ino = dir_resolve_path(parent_path);
+
     if (parent_ino < 0) {
         fs_write_unlock();
         return -ENOENT;
     }
-    /* Check if file already exists */
-    if (dir_lookup(parent_ino, filename) >= 0) {
+
+    if (dir_lookup((uint32_t)parent_ino, filename) >= 0) {
         fs_write_unlock();
         return -EEXIST;
     }
-    int ino = file_create(parent_ino, filename, mode & 0777);
+
+    int ino = file_create((uint32_t)parent_ino, filename, mode & 0777);
+
     if (ino < 0) {
         fs_write_unlock();
         return -EIO;
     }
-    int fd = file_open(ino, COUGFS_O_RDWR);
+
+    int fd = file_open((uint32_t)ino, COUGFS_O_RDWR);
+
     if (fd < 0) {
-        /* Clean up orphan file */
-        file_delete(parent_ino, filename);
+        file_delete((uint32_t)parent_ino, filename);
         fs_write_unlock();
         return -EIO;
     }
+
     fi->fh = fd;
+
     fs_write_unlock();
     return 0;
 }
@@ -214,90 +301,126 @@ static int cougfs_create(const char *path, mode_t mode,
 static int cougfs_unlink(const char *path)
 {
     fs_write_lock();
+
     char parent_path[1024];
     char filename[MAX_NAME_LEN + 1];
+
     if (split_path(path, parent_path, filename) < 0) {
         fs_write_unlock();
         return -EINVAL;
     }
+
     int parent_ino = dir_resolve_path(parent_path);
+
     if (parent_ino < 0) {
         fs_write_unlock();
         return -ENOENT;
     }
-    if (dir_lookup(parent_ino, filename) < 0) {
+
+    if (dir_lookup((uint32_t)parent_ino, filename) < 0) {
         fs_write_unlock();
         return -ENOENT;
     }
-    int ret = file_delete(parent_ino, filename);
+
+    int ret = file_delete((uint32_t)parent_ino, filename);
+
     fs_write_unlock();
+
     return ret < 0 ? -EIO : 0;
 }
 
 static int cougfs_mkdir(const char *path, mode_t mode)
 {
     fs_write_lock();
+
     char parent_path[1024];
     char dirname[MAX_NAME_LEN + 1];
+
     if (split_path(path, parent_path, dirname) < 0) {
         fs_write_unlock();
         return -EINVAL;
     }
+
     int parent_ino = dir_resolve_path(parent_path);
+
     if (parent_ino < 0) {
         fs_write_unlock();
         return -ENOENT;
     }
-    if (dir_lookup(parent_ino, dirname) >= 0) {
+
+    if (dir_lookup((uint32_t)parent_ino, dirname) >= 0) {
         fs_write_unlock();
         return -EEXIST;
     }
-    int ret = dir_create(parent_ino, dirname, mode & 0777);
+
+    int ret = dir_create((uint32_t)parent_ino, dirname, mode & 0777);
+
     fs_write_unlock();
+
     return ret < 0 ? -EIO : 0;
 }
 
 static int cougfs_rmdir(const char *path)
 {
     fs_write_lock();
+
     char parent_path[1024];
     char dirname[MAX_NAME_LEN + 1];
+
     if (split_path(path, parent_path, dirname) < 0) {
         fs_write_unlock();
         return -EINVAL;
     }
+
     int parent_ino = dir_resolve_path(parent_path);
+
     if (parent_ino < 0) {
         fs_write_unlock();
         return -ENOENT;
     }
-    int ino = dir_lookup(parent_ino, dirname);
+
+    int ino = dir_lookup((uint32_t)parent_ino, dirname);
+
     if (ino < 0) {
         fs_write_unlock();
         return -ENOENT;
     }
-    if (!dir_is_empty(ino)) {
+
+    if (!dir_is_empty((uint32_t)ino)) {
         fs_write_unlock();
         return -ENOTEMPTY;
     }
-    int ret = dir_remove(parent_ino, dirname);
+
+    int ret = dir_remove((uint32_t)parent_ino, dirname);
+
     fs_write_unlock();
+
     return ret < 0 ? -EIO : 0;
 }
 
 static int cougfs_truncate(const char *path, off_t size)
 {
-    if (size < 0 || (uint64_t)size > UINT32_MAX) {
+    if (size < 0)
         return -EINVAL;
-    }
+
+    uint64_t max_size = (uint64_t)MAX_FILE_BLOCKS * BLOCK_SIZE;
+
+    if ((uint64_t)size > max_size)
+        return -EINVAL;
+
     fs_write_lock();
+
     int ino = dir_resolve_path(path);
+
     if (ino < 0) {
         fs_write_unlock();
         return -ENOENT;
     }
-    int ret = file_truncate(ino, (uint32_t)size);
+
+    int ret = file_truncate((uint32_t)ino, (uint32_t)size);
+
     fs_write_unlock();
+
     return ret < 0 ? -EIO : 0;
 }
 
@@ -321,8 +444,11 @@ int cougfs_fuse_main(int argc, char *argv[], const char *disk_path)
         fprintf(stderr, "Failed to mount CougFS from %s\n", disk_path);
         return 1;
     }
+
     int ret = fuse_main(argc, argv, &cougfs_ops, NULL);
+
     fs_unmount();
+
     return ret;
 }
 
@@ -336,6 +462,7 @@ int cougfs_fuse_main(int argc, char *argv[], const char *disk_path)
     (void)argc;
     (void)argv;
     (void)disk_path;
+
     fprintf(stderr, "FUSE support not compiled. Rebuild with ENABLE_FUSE=1.\n");
     return 1;
 }

--- a/src/fuse_ops.c
+++ b/src/fuse_ops.c
@@ -174,12 +174,24 @@ static int cougfs_open(const char *path, struct fuse_file_info *fi)
     else if ((fi->flags & O_ACCMODE) == O_WRONLY)
         flags = COUGFS_O_WRONLY;
 
+    cougfs_inode_t inode;
+
+    if (inode_read((uint32_t)ino, &inode) < 0) {
+        fs_write_unlock();
+        return -EIO;
+    }
+
+    if ((inode.mode & COUGFS_S_IFMT) == COUGFS_S_IFDIR) {
+        fs_write_unlock();
+        return -EISDIR;
+    }
+
     int fd = file_open((uint32_t)ino, flags);
 
     if (fd < 0) {
         fs_write_unlock();
-        return -EISDIR;
-    }
+        return -EIO;
+}
 
     fi->fh = fd;
 
@@ -267,9 +279,16 @@ static int cougfs_create(const char *path, mode_t mode,
 
     int parent_ino = dir_resolve_path(parent_path);
 
-    if (parent_ino < 0) {
+    cougfs_inode_t parent_inode;
+
+    if (inode_read((uint32_t)parent_ino, &parent_inode) < 0) {
         fs_write_unlock();
-        return -ENOENT;
+        return -EIO;
+    }
+
+    if ((parent_inode.mode & COUGFS_S_IFMT) != COUGFS_S_IFDIR) {
+        fs_write_unlock();
+        return -ENOTDIR;
     }
 
     if (dir_lookup((uint32_t)parent_ino, filename) >= 0) {
@@ -343,9 +362,16 @@ static int cougfs_mkdir(const char *path, mode_t mode)
 
     int parent_ino = dir_resolve_path(parent_path);
 
-    if (parent_ino < 0) {
+    cougfs_inode_t parent_inode;
+
+    if (inode_read((uint32_t)parent_ino, &parent_inode) < 0) {
         fs_write_unlock();
-        return -ENOENT;
+        return -EIO;
+    }
+
+    if ((parent_inode.mode & COUGFS_S_IFMT) != COUGFS_S_IFDIR) {
+        fs_write_unlock();
+        return -ENOTDIR;
     }
 
     if (dir_lookup((uint32_t)parent_ino, dirname) >= 0) {
@@ -374,9 +400,16 @@ static int cougfs_rmdir(const char *path)
 
     int parent_ino = dir_resolve_path(parent_path);
 
-    if (parent_ino < 0) {
+    cougfs_inode_t target_inode;
+
+    if (inode_read((uint32_t)ino, &target_inode) < 0) {
         fs_write_unlock();
-        return -ENOENT;
+        return -EIO;
+    }
+
+    if ((target_inode.mode & COUGFS_S_IFMT) != COUGFS_S_IFDIR) {
+        fs_write_unlock();
+        return -ENOTDIR;
     }
 
     int ino = dir_lookup((uint32_t)parent_ino, dirname);
@@ -386,10 +419,10 @@ static int cougfs_rmdir(const char *path)
         return -ENOENT;
     }
 
-    if (!dir_is_empty((uint32_t)ino)) {
+    if (dir_lookup((uint32_t)parent_ino, filename) < 0) {
         fs_write_unlock();
-        return -ENOTEMPTY;
-    }
+        return -ENOENT;
+}
 
     int ret = dir_remove((uint32_t)parent_ino, dirname);
 

--- a/src/inode.c
+++ b/src/inode.c
@@ -105,7 +105,9 @@ int inode_free(uint32_t ino)
     }
 
     memset(&inode, 0, sizeof(inode));
-    inode_write(ino, &inode);
+    if (inode_write(ino, &inode) < 0)
+        return -1;
+
     bitmap_free_inode(ino);
     bitmap_sync();
 
@@ -249,9 +251,10 @@ int inode_truncate(uint32_t ino, cougfs_inode_t *inode, uint32_t new_size)
         uint32_t zero_buf[BLOCK_SIZE / sizeof(uint32_t)];
         memset(zero_buf, 0, sizeof(zero_buf));
 
-        disk_write_block(inode->indirect, zero_buf);
-        bitmap_free_block(inode->indirect);
+        if (disk_write_block(inode->indirect, zero_buf) < 0)
+            return -1;
 
+        bitmap_free_block(inode->indirect);
         inode->indirect = INVALID_BLOCK;
         indirect_dirty = 0;
     } else if (indirect_dirty) {

--- a/src/inode.c
+++ b/src/inode.c
@@ -11,11 +11,15 @@ int inode_read(uint32_t ino, cougfs_inode_t *inode)
         fprintf(stderr, "inode_read: inode %u out of range\n", ino);
         return -1;
     }
+
     uint32_t block = INODE_TABLE_START + (ino / INODES_PER_BLOCK);
     uint32_t offset_in_block = (ino % INODES_PER_BLOCK) * INODE_SIZE;
+
     uint8_t buf[BLOCK_SIZE];
+
     if (disk_read_block(block, buf) < 0)
         return -1;
+
     memcpy(inode, buf + offset_in_block, sizeof(cougfs_inode_t));
     return 0;
 }
@@ -26,24 +30,33 @@ int inode_write(uint32_t ino, const cougfs_inode_t *inode)
         fprintf(stderr, "inode_write: inode %u out of range\n", ino);
         return -1;
     }
+
     uint32_t block = INODE_TABLE_START + (ino / INODES_PER_BLOCK);
     uint32_t offset_in_block = (ino % INODES_PER_BLOCK) * INODE_SIZE;
+
     uint8_t buf[BLOCK_SIZE];
+
     if (disk_read_block(block, buf) < 0)
         return -1;
+
     memcpy(buf + offset_in_block, inode, sizeof(cougfs_inode_t));
+
     if (disk_write_block(block, buf) < 0)
         return -1;
+
     return 0;
 }
 
 int inode_alloc(uint16_t mode)
 {
     int ino = bitmap_alloc_inode();
+
     if (ino < 0)
         return -1;
+
     cougfs_inode_t inode;
     memset(&inode, 0, sizeof(inode));
+
     inode.mode = mode;
     inode.uid = 0;
     inode.gid = 0;
@@ -53,10 +66,12 @@ int inode_alloc(uint16_t mode)
     inode.mtime = inode.atime;
     inode.ctime = inode.atime;
     inode.blocks = 0;
+
     if (inode_write(ino, &inode) < 0) {
         bitmap_free_inode(ino);
         return -1;
     }
+
     bitmap_sync();
     return ino;
 }
@@ -64,29 +79,36 @@ int inode_alloc(uint16_t mode)
 int inode_free(uint32_t ino)
 {
     cougfs_inode_t inode;
+
     if (inode_read(ino, &inode) < 0)
         return -1;
+
     for (int i = 0; i < DIRECT_BLOCKS; i++) {
         if (inode.direct[i] != INVALID_BLOCK) {
             bitmap_free_block(inode.direct[i]);
             inode.direct[i] = INVALID_BLOCK;
         }
     }
+
     if (inode.indirect != INVALID_BLOCK) {
         uint32_t indirect_buf[BLOCK_SIZE / sizeof(uint32_t)];
+
         if (disk_read_block(inode.indirect, indirect_buf) == 0) {
             for (uint32_t i = 0; i < BLOCK_SIZE / sizeof(uint32_t); i++) {
                 if (indirect_buf[i] != INVALID_BLOCK)
                     bitmap_free_block(indirect_buf[i]);
             }
         }
+
         bitmap_free_block(inode.indirect);
         inode.indirect = INVALID_BLOCK;
     }
+
     memset(&inode, 0, sizeof(inode));
     inode_write(ino, &inode);
     bitmap_free_inode(ino);
     bitmap_sync();
+
     return 0;
 }
 
@@ -94,15 +116,23 @@ static uint32_t handle_direct_block(cougfs_inode_t *inode, uint32_t logical_bloc
 {
     if (inode->direct[logical_block] != INVALID_BLOCK)
         return inode->direct[logical_block];
+
     if (!alloc)
         return INVALID_BLOCK;
+
     int blk = bitmap_alloc_block();
+
     if (blk < 0)
         return INVALID_BLOCK;
-    if (disk_zero_and_write_block((uint32_t)blk) < 0)
+
+    if (disk_zero_and_write_block((uint32_t)blk) < 0) {
+        bitmap_free_block((uint32_t)blk);
         return INVALID_BLOCK;
+    }
+
     inode->direct[logical_block] = (uint32_t)blk;
     inode->blocks++;
+
     return (uint32_t)blk;
 }
 
@@ -111,33 +141,56 @@ static uint32_t handle_indirect_block(cougfs_inode_t *inode,
                                       int alloc)
 {
     uint32_t indirect_idx = logical_block - DIRECT_BLOCKS;
+
     if (indirect_idx >= BLOCK_SIZE / sizeof(uint32_t))
         return INVALID_BLOCK;
+
     if (inode->indirect == INVALID_BLOCK) {
         if (!alloc)
             return INVALID_BLOCK;
+
         int iblk = bitmap_alloc_block();
+
         if (iblk < 0)
             return INVALID_BLOCK;
-        if (disk_zero_and_write_block((uint32_t)iblk) < 0)
+
+        if (disk_zero_and_write_block((uint32_t)iblk) < 0) {
+            bitmap_free_block((uint32_t)iblk);
             return INVALID_BLOCK;
+        }
+
         inode->indirect = (uint32_t)iblk;
     }
+
     uint32_t indirect_buf[BLOCK_SIZE / sizeof(uint32_t)];
+
     if (disk_read_block(inode->indirect, indirect_buf) < 0)
         return INVALID_BLOCK;
+
     if (indirect_buf[indirect_idx] != INVALID_BLOCK)
         return indirect_buf[indirect_idx];
+
     if (!alloc)
         return INVALID_BLOCK;
+
     int dblk = bitmap_alloc_block();
+
     if (dblk < 0)
         return INVALID_BLOCK;
-    if (disk_zero_and_write_block((uint32_t)dblk) < 0)
+
+    if (disk_zero_and_write_block((uint32_t)dblk) < 0) {
+        bitmap_free_block((uint32_t)dblk);
         return INVALID_BLOCK;
+    }
+
     indirect_buf[indirect_idx] = (uint32_t)dblk;
-    if (disk_write_block(inode->indirect, indirect_buf) < 0)
+
+    if (disk_write_block(inode->indirect, indirect_buf) < 0) {
+        bitmap_free_block((uint32_t)dblk);
+        indirect_buf[indirect_idx] = INVALID_BLOCK;
         return INVALID_BLOCK;
+    }
+
     inode->blocks++;
     return (uint32_t)dblk;
 }
@@ -146,6 +199,7 @@ uint32_t inode_get_block(cougfs_inode_t *inode, uint32_t logical_block, int allo
 {
     if (logical_block < DIRECT_BLOCKS)
         return handle_direct_block(inode, logical_block, alloc);
+
     return handle_indirect_block(inode, logical_block, alloc);
 }
 
@@ -153,37 +207,64 @@ int inode_truncate(uint32_t ino, cougfs_inode_t *inode, uint32_t new_size)
 {
     uint32_t max_size = MAX_FILE_BLOCKS * BLOCK_SIZE;
 
-    if (new_size > max_size) {
+    if (new_size > max_size)
         return -1;
-    }
 
     uint32_t old_blocks = (inode->size + BLOCK_SIZE - 1) / BLOCK_SIZE;
     uint32_t new_blocks = (new_size + BLOCK_SIZE - 1) / BLOCK_SIZE;
+
     if (new_size == 0)
         new_blocks = 0;
+
+    uint32_t indirect_buf[BLOCK_SIZE / sizeof(uint32_t)];
+    int indirect_loaded = 0;
+    int indirect_dirty = 0;
+
+    if (inode->indirect != INVALID_BLOCK && old_blocks > DIRECT_BLOCKS) {
+        if (disk_read_block(inode->indirect, indirect_buf) < 0)
+            return -1;
+
+        indirect_loaded = 1;
+    }
+
     for (uint32_t i = new_blocks; i < old_blocks; i++) {
         uint32_t blk = inode_get_block(inode, i, 0);
+
         if (blk != INVALID_BLOCK) {
             bitmap_free_block(blk);
+
             if (i < DIRECT_BLOCKS) {
                 inode->direct[i] = INVALID_BLOCK;
+            } else if (indirect_loaded) {
+                indirect_buf[i - DIRECT_BLOCKS] = INVALID_BLOCK;
+                indirect_dirty = 1;
             }
-            inode->blocks--;
+
+            if (inode->blocks > 0)
+                inode->blocks--;
         }
     }
+
     if (new_blocks <= DIRECT_BLOCKS && inode->indirect != INVALID_BLOCK) {
-        /* Zero out indirect block entries before freeing to prevent
-         * stale pointers if the block is reallocated later */
         uint32_t zero_buf[BLOCK_SIZE / sizeof(uint32_t)];
         memset(zero_buf, 0, sizeof(zero_buf));
-        disk_write_block(inode->indirect, zero_buf);
 
+        disk_write_block(inode->indirect, zero_buf);
         bitmap_free_block(inode->indirect);
+
         inode->indirect = INVALID_BLOCK;
+        indirect_dirty = 0;
+    } else if (indirect_dirty) {
+        if (disk_write_block(inode->indirect, indirect_buf) < 0)
+            return -1;
     }
+
     inode->size = new_size;
     inode->mtime = (uint32_t)time(NULL);
-    inode_write(ino, inode);
+
+    if (inode_write(ino, inode) < 0)
+        return -1;
+
     bitmap_sync();
     return 0;
 }


### PR DESCRIPTION
Fixes reliability and safety issues in CougFS, including stale block pointer handling, safer FUSE validation, improved path/offset checks, and stronger error handling

Testing:
- make passed
- make test passed: 85/85
- make valgrind passed: 0 leaks, 0 errors
- manual shell testing passed
- manual indirect-block corruption test passed"